### PR TITLE
Добавлен отступ снизу в NavigationBar для устройств, у которых есть отступы в safe area

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -67,15 +67,15 @@ const useStyles = makeStyles({
     display: 'flex',
     minHeight: `calc(100vh - ${APP_BAR_HEIGHT}px - ${
       isMobile() ? chromeAddressBarHeight : 0
-    }px - ${shouldShowAppBar ? BOTTOM_BAR_HEIGHT : 0}px)`,
+    }px - ${shouldShowAppBar ? BOTTOM_BAR_HEIGHT : 0}px + env(safe-area-inset-bottom, 0px))`,
     borderRadius: 0,
     alignItems: 'flex-start',
     flexDirection: 'row',
     width: '100%',
     maxWidth: maxWidth,
-    margin: `${APP_BAR_HEIGHT}px auto ${
+    margin: `${APP_BAR_HEIGHT}px auto calc(${
       shouldShowAppBar ? BOTTOM_BAR_HEIGHT : 0
-    }px auto`,
+    }px + env(safe-area-inset-bottom, 0px)) auto`,
     boxSizing: 'border-box',
     [theme.breakpoints.up(MIDDLE_WIDTH)]: {
       marginTop: 0,

--- a/src/components/blocks/BottomBar.tsx
+++ b/src/components/blocks/BottomBar.tsx
@@ -31,6 +31,7 @@ const useStyles = makeStyles((theme) => ({
   container: {
     background: getContrastPaperColor(theme),
     height: BOTTOM_BAR_HEIGHT,
+    paddingBottom: 'env(safe-area-inset-bottom, 0)',
   },
   item: {
     fontFamily: 'Google Sans',

--- a/src/components/blocks/UpdateNotification.tsx
+++ b/src/components/blocks/UpdateNotification.tsx
@@ -108,9 +108,9 @@ const UpdateNotification = () => {
     <div
       className={classes.rootWrapper}
       style={{
-        transform: `translateY(${
+        transform: `translateY(calc(${
           noBottomMargin ? 0 : -1 * BOTTOM_BAR_HEIGHT
-        }px)`,
+        }px + env(safe-area-inset-bottom, 0px)))`,
       }}
     >
       <ButtonBase className={classes.root} onClick={onClick}>

--- a/src/pages/Comments/index.tsx
+++ b/src/pages/Comments/index.tsx
@@ -77,7 +77,7 @@ const useStyles = makeStyles((theme) => ({
       APP_BAR_HEIGHT * 3
     }px - ${BOTTOM_BAR_HEIGHT}px - ${
       isMobile() ? chromeAddressBarHeight : 0
-    }px)`,
+    }px - env(safe-area-inset-bottom, 0px))`,
   },
   highlightComment: {
     animation: `$highlightComment 750ms ${theme.transitions.easing.easeOut}`,


### PR DESCRIPTION
Особенно важно для устройств без кнопок снизу, для управления которых используется полоса.

До:
![image](https://user-images.githubusercontent.com/12175048/133076739-91425f7f-1bae-4371-a271-b11e72a9d51f.png)

После:
![image](https://user-images.githubusercontent.com/12175048/133076759-76e10a39-2512-49cd-9ae6-966215f514dc.png)
