### PR TITLE
фикс картинок компаний в заголовке поста

### DIFF
--- a/src/pages/Post/CompanyCard.tsx
+++ b/src/pages/Post/CompanyCard.tsx
@@ -100,17 +100,15 @@ const useStyles = makeStyles((theme) => ({
   companyHeader: {
     width: '100%',
     borderRadius: 0,
-    minHeight: 'calc(100% / 4.4)',
+    height: 'calc(100% / 4.4)',
   },
   brandingLink: {
     display: 'flex',
-    height: '100%',
     position: 'relative',
     background: theme.palette.action.hover,
     '&::before': {
       paddingBottom: 'calc(100% / 4.4)',
       content: '""',
-      width: '100%',
     },
   },
 }))


### PR DESCRIPTION

### Firefox 92:
<img src="https://user-images.githubusercontent.com/52159053/134959099-e76b2c40-f2e7-492b-b523-33c481f4cfe6.png" width="600" >

### Safari iOS 14:
<img src="https://user-images.githubusercontent.com/52159053/134959214-29e36588-e1c0-4f9f-b9f4-b65e5c350ff5.png" height="400" >
