### PR TITLE
FIX: Растягивание изображения во flexbox в Safari

### DIFF
--- a/src/components/blocks/LazyLoadImage.tsx
+++ b/src/components/blocks/LazyLoadImage.tsx
@@ -15,6 +15,7 @@ const useStyles = makeStyles((theme) => ({
   imageContainer: {
     overflow: 'hidden',
     display: 'inline-flex',
+    flexDirection: 'column',
   },
   image: {
     height: 'auto',


### PR DESCRIPTION
На iOS в Safari картинки растягивались. Данный PR фиксит это

### Было / Стало
<img src="https://user-images.githubusercontent.com/52159053/135253989-e7c29394-c614-4fcb-ba2f-9b8b0229399c.png" width="300" > <img src="https://user-images.githubusercontent.com/52159053/135254135-ad8ced16-4223-495a-8e6d-4513abeba8aa.png" width="300" >
